### PR TITLE
Fixed a bug

### DIFF
--- a/ggdc-robot.py
+++ b/ggdc-robot.py
@@ -251,7 +251,7 @@ def ggdc_submit(url, email, blastVariant, queryfile, reffile):
                           (rline, open(rline,"rb"),"application/octet-stream"))
             mrg_form_values.append(form_value)
         form[4] = mrg_form_values.pop(-1)
-        for v in mrg_form_values:
+        for v in range(len(mrg_form_values)):
             form.insert(4, mrg_form_values.pop(-1))
     else: sys.exit('Unable to submit reference' + refformat + '. Exiting.')
 


### PR DESCRIPTION
Following code:
```
for v in mrg_form_values:
    form.insert(4, mrg_form_values.pop(-1))
```
pops of the last elements of a list while looping over the list, essentially shortening the list while looping. This would skip the first half of the files when submitting multiple query files (more than 2).

Current fix just loops for the number of files in the initial list instead of looping over the list. So it does not care if the list becomes shorter during the loop.

Alternatively you could also loop over the list backwards.